### PR TITLE
fix(galaxy): add .js suffix to OrbitControls import

### DIFF
--- a/src/components/Galaxy/Galaxy.tsx
+++ b/src/components/Galaxy/Galaxy.tsx
@@ -13,7 +13,7 @@
 
 import { useEffect } from "react";
 import * as THREE from "three";
-import { OrbitControls } from "three/examples/jsm/controls/OrbitControls";
+import { OrbitControls } from "three/examples/jsm/controls/OrbitControls.js";
 
 interface InitGalaxyFn {
   (): void;


### PR DESCRIPTION
## Summary

- Adds explicit `.js` suffix to the `OrbitControls` import in `src/components/Galaxy/Galaxy.tsx` so the subpath resolves under newer `@types/three` versions.
- Unblocks dependabot PR #42 (`three` 0.183.2 → 0.184.0, `@types/three` 0.136.1 → 0.184.0), whose Vercel build was failing with `Cannot find module 'three/examples/jsm/controls/OrbitControls' or its corresponding type declarations`.

## Why this is needed

`@types/three@0.184.0` introduced a `package.exports` field whose `./examples/jsm/*` wildcard maps 1:1 without appending file extensions. Extensionless subpath imports therefore stop resolving under bundler module resolution. Adding `.js` matches both the current pinned versions and the bumped versions.

## Test plan

- [x] `pnpm typecheck` passes on current pinned versions
- [x] `pnpm typecheck` passes on bumped versions (`three@0.184.0` + `@types/three@0.184.0`)
- [x] `pnpm lint` passes
- [x] `pnpm build` passes