### PR TITLE
fix(galaxy): catch WebGL context creation failures

### DIFF
--- a/src/components/Galaxy/Galaxy.tsx
+++ b/src/components/Galaxy/Galaxy.tsx
@@ -120,7 +120,14 @@ type ThreeProps = { props?: { [key: string]: any } };
 
 export const Galaxy = ({ ...props }: ThreeProps) => {
   useEffect(() => {
-    initGalaxy();
+    try {
+      initGalaxy();
+    } catch (err) {
+      // WebGL context creation can fail in sandboxed/privacy browsers (Arc, Brave shields,
+      // hardware-accel disabled). The galaxy is decorative — swallow the error so the
+      // rest of the page keeps rendering.
+      console.warn("Galaxy disabled: WebGL unavailable", err);
+    }
 
     return initGalaxy.cleanUp;
   }, []);


### PR DESCRIPTION
## Summary

The Galaxy three.js scene calls \`new THREE.WebGLRenderer()\` unconditionally on mount. In browsers where canvas \`getContext('webgl')\` returns \`null\` — Arc's strict sandbox, Brave with shields, hardware-accel disabled, etc. — this throws \`Error: Error creating WebGL context\` and the unhandled exception crashes the whole React tree. The user sees the browser's "This page couldn't load" error page instead of the site.

Wraps \`initGalaxy()\` in try/catch and logs a warning. The galaxy is purely decorative, so dropping it doesn't affect functionality.

## Verified

Reproduced and fixed in Chrome DevTools by stubbing \`HTMLCanvasElement.prototype.getContext\` to return null for any \`webgl*\` request:

- Before: page crashes, blank screen, \`Uncaught Error: Error creating WebGL context\`.
- After: warning logged (\`Galaxy disabled: WebGL unavailable\`), hero / header / theme toggle / scroll indicator all render normally; only the star-field background is omitted.

## Test plan

- [ ] CI green
- [ ] Vercel preview opens in Arc without "This page couldn't load"