### PR TITLE
fix(projects): restore video thumbnail container fill

### DIFF
--- a/src/components/Projects/Project/ResponsivePlayer/ClientOnlyPlayer.tsx
+++ b/src/components/Projects/Project/ResponsivePlayer/ClientOnlyPlayer.tsx
@@ -3,7 +3,7 @@ import { ComponentProps } from "react";
 
 const ReactPlayer = dynamic(() => import("react-player"), {
   ssr: false,
-  loading: () => <div style={{ aspectRatio: "16/9", background: "#000" }} />,
+  loading: () => <div style={{ position: "absolute", inset: 0, background: "#000" }} />,
 });
 
 type ClientOnlyPlayerProps = ComponentProps<typeof ReactPlayer>;

--- a/src/components/Projects/Project/ResponsivePlayer/ResponsivePlayer.tsx
+++ b/src/components/Projects/Project/ResponsivePlayer/ResponsivePlayer.tsx
@@ -10,21 +10,14 @@ type ResponsivePlayerProps = {
 
 export const ResponsivePlayer = ({ video, img }: ResponsivePlayerProps) => {
   return (
-    <div
-      style={{
-        ...style.playerWrapper,
-        paddingTop: calcVidRatio(img.width, img.height) + "%",
-      }}
-      className="w-full"
-    >
+    <div className="relative w-full" style={{ aspectRatio: `${img.width} / ${img.height}` }}>
       <ClientOnlyPlayer
+        wrapper="div"
         playing={true}
         src={video.src}
-        style={style.reactPlayer}
+        style={{ position: "absolute", inset: 0 }}
         width="100%"
         height="100%"
-        // width={video.width}
-        // height={video.height}
         muted
         loop
         controls
@@ -33,17 +26,4 @@ export const ResponsivePlayer = ({ video, img }: ResponsivePlayerProps) => {
       />
     </div>
   );
-};
-
-const calcVidRatio = (width: number, height: number): number => 100 / (width / height);
-
-const style = {
-  playerWrapper: {
-    position: "relative" as const,
-  },
-  reactPlayer: {
-    position: "absolute" as const,
-    top: 0,
-    left: 0,
-  },
 };


### PR DESCRIPTION
react-player v3's default wrapper changed to ForwardChildren, which
renders no DOM element, so width/height/style props no longer reach a
container div. This broke the responsive padding-top aspect-ratio
container, leaving the thumbnail at its intrinsic size.

Pass wrapper="div" so the player has a real wrapper that receives the
sizing styles, and switch to the modern aspect-ratio CSS property.